### PR TITLE
Track and squash respawned events

### DIFF
--- a/UnitTests.html
+++ b/UnitTests.html
@@ -45,7 +45,7 @@ function playerSerialize(){
 function moveSerialize(){
     let move = new MovePlayer(0.1, {player_id:9, interval:0.1 }) ;
     let serial = move.serialize();
-    console.assert(serial == `{"event":"MovePlayer","time":0.1,"parameters":{"player_id":9,"interval":0.1}}`, "Move failed serialize: " + serial);
+    console.assert(serial == `{"event":"MovePlayer","time":0.1,"spawned_by":"","parameters":{"player_id":9,"interval":0.1}}`, "Move failed serialize: " + serial);
     let np = TEvent.getEventBySerialized(serial) ;
     let serial2 = np.serialize();
     console.assert(serial2 == serial, "Move failed reserialize: " + serial2 +" != " + serial);
@@ -80,7 +80,48 @@ function addPlayerAndMove(){
 }
 
 function synchronizetoEmptyTimeline(){
-    //TODO
+    // Sync some basic starting events into an empty timeline
+    let timeline = getPlayerMoveStart() ;
+    let timeline2 = new Timeline(0);
+    let sync_base_time = -1 ; // Syncb ase before timeline starts mean we want everything
+    let t1hash1 = timeline.getHashData(sync_base_time);
+    console.assert(t1hash1.events.length == 2, "Starting timeline hash has wrong number of events!", t1hash1);
+    console.assert(Object.keys(t1hash1.base).length == 0, "Starting timeline hash has objects when it shouldn't!", t1hash1);
+
+    let t2hash1 = timeline2.getHashData(sync_base_time);
+    console.assert(t2hash1.events.length == 0, "Empty timeline hash has wrong umber of events!", t2hash1);
+
+    let update1 = timeline.getUpdateFor(t2hash1, sync_base_time);
+    console.assert(update1.events.length == 2, "Update 1 has wrong number of events!", update1);
+
+    timeline2.applyUpdate(update1, true);
+    let t2hash2 = timeline2.getHashData(sync_base_time) ;
+    console.assert(JSON.stringify(t1hash1) == JSON.stringify(t2hash2), 
+        "Hashes don't match when syncing a timeline data to an empty timeline!\n",
+    );
+
+    // Step the server forward twice to generate some new events and an object
+    sync_base_time = 0 ; // Move forward so we get the created objectand not the event that makes it
+    timeline.current_time += 0.2;
+    timeline.executeToTime(timeline.current_time);
+    let t1hash2 = timeline.getHashData(sync_base_time);
+    console.assert(t1hash2.events.length == 3, "Stepped timeline hash has wrong number of events!", t1hash2);
+    console.assert(Object.keys(t1hash2.base).length == 1, "Stepped timeline hash has wrong nuber of objects", t1hash2);
+
+    let update2 = timeline.getUpdateFor(t2hash2, sync_base_time);
+    console.assert(update2.events.length == 2, "Update 2 has wrong number of events!", update2);
+    console.assert(Object.keys(update2.base).length == 1, "Update 2 has wrong number of objects!", update2) ;
+    timeline2.applyUpdate(update2, true);
+    let t2hash3 = timeline2.getHashData(sync_base_time) ;
+    console.assert(t2hash3.events.length == 3, "Post-update2 hash has wrong number of events.", t2hash3.events);
+    console.assert(Object.keys(t2hash3.base).length == 1, "Post-update2 hash has wrong number of objects.", t2hash3.base);
+
+    // Running the clock forward on the client should overwrite synced events from the future and produce identical results without duplicating anything
+    timeline2.current_time += 0.2 ;
+    timeline2.executeToTime(timeline2.current_time);
+    let t2hash4 = timeline2.getHashData(sync_base_time) ;
+    t2hash3.current_time = t2hash4.current_time ; // Everything else should be the same 
+    console.assert(JSON.stringify(t2hash3) == JSON.stringify(t2hash4), "Running a synced timeline gets divergent results! ", timeline2);
 
 }
 function synchronizeChangingVelocity(){

--- a/timeline_core/TEvent.js
+++ b/timeline_core/TEvent.js
@@ -8,13 +8,14 @@ class TEvent{
 
     read_ids = {};
     write_ids = {};
+    spawned_by =""; // The hash of the event that created this event if it was created by another event
 
     constructor(time){
         this.time = time;
     }
 
     serialize(){
-        return JSON.stringify({event:this.constructor.name, time:this.time, parameters:this.parameters});
+        return JSON.stringify({event:this.constructor.name, time:this.time, spawned_by:this.spawned_by, parameters:this.parameters});
     }
 
     hash(){
@@ -37,6 +38,7 @@ class TEvent{
         let es = "ev = new "+p.event+"(" + p.time +", " + JSON.stringify(p.parameters) +");" ;
         //console.log(es);
         eval(es); // TODO got to be a better way also every class needs an empty constructor for this to work
+        ev.spawned_by = p.spawned_by;
         return ev ;
     }
 


### PR DESCRIPTION
When events are spawned from inside other events, and the spawning event is rerun it could cause events to be duplicated in the timeline. This is almost guaranteed to occur during networking since the server will send events spawned by events that haven't run yet on the client. This change adds automatic tracing and squashing of spawned events, so this does not occur without changing the user API.

The unit test synchronizetoEmptyTimeline() has been updated to include a basic version of this issue that previously occurred. 

There are also a bunch of small updates mixed in here, like base object updates now send their real created time , and some edge cases around timing have been resolved.