### PR TITLE
improve clock sync

### DIFF
--- a/ChatClient.html
+++ b/ChatClient.html
@@ -37,15 +37,13 @@ var base_age = 2 ;
 var my_id = -1 ;
 var chat_id = -1 ;
 var player_radius = 30;
-var player_speed = 800;
+var player_speed = 1000;
 var player_fill = "#D0D0D0";
 var player_stroke = "#D000D0" ;
 var stroke_size = 4 ;
 var visual_buffer = 0.07;
-var action_delay = 0.07;
-var player_ahead = 0.035;
-
-var last_run_time = new Date().getTime();
+var action_delay = 0.06;
+var player_ahead = 0.045;
 
 var last_chat_text = "";
 
@@ -82,7 +80,7 @@ function canvasApp() {
 		window.addEventListener("mousemove", mouseMoveListener, false);
 		window.addEventListener("mouseup", mouseUpListener, false);
 		window.addEventListener('keydown',keyListener,false);
-		setInterval(timeListener, 1000*interval); // Timer
+        requestAnimationFrame(timeListener);
 
         // Execute a function when the user releases a key on the keyboard
         document.getElementById("textbox").addEventListener("keyup", function(event) {
@@ -166,7 +164,7 @@ function canvasApp() {
             let dx = mouse_x - me.x;
             let dy = mouse_y - me.y;
             let d2 = dx*dx+ dy*dy ;
-            if(d2 > 100){ // not there
+            if(d2 > 225){ // not there
                 let d1 = Math.sqrt(d2);
                 vx = dx * player_speed/d1;
                 vy = dy * player_speed/d1;
@@ -180,13 +178,11 @@ function canvasApp() {
         }
 
         // Advance time
-        let time = new Date().getTime()
-        let real_interval = (time-last_run_time)/1000.0;
-        last_run_time = time ;
-        timeline.run(real_interval);
+        timeline.run();
         
 		// Draw screen.
 		drawScreen();
+        requestAnimationFrame(timeListener);
 	}
 	
 	function keyListener(evt) {

--- a/ChatServer.js
+++ b/ChatServer.js
@@ -22,9 +22,7 @@ include('./events/MovePlayer.js');
 include('./events/AddChatLine.js');
 include('./events/UpdatePlayerVelocity.js');
 
-var interval = 1.0/30 ; // step size in seconds
 var timeline ;
-var last_run_time = new Date().getTime();
 
 var port = 8081;
 var tserver ;
@@ -38,12 +36,9 @@ function setUpGame(){
 }
 
 function tick(){
-    let time = new Date().getTime() ;
-    let real_interval = (time-last_run_time)/1000.0;
-    last_run_time = time ;
-    timeline.run(real_interval);
+    timeline.run();
 }
 
 setUpGame();
 tserver = new TServer(timeline, port, WebSocket);
-setInterval(tick, 1000*interval);
+setInterval(tick, 10);

--- a/UnitTests.html
+++ b/UnitTests.html
@@ -127,6 +127,7 @@ function synchronizeChangingVelocity(){
     let packet = {update:server.getUpdateFor(client.getHashData(0), 0), hash_data:server.getHashData(0)};
     // apply packet to timeline 2 and generate packet for timeline 1
     packet = client.synchronize(packet.hash_data, packet.update, true, client.current_time-Timeline.sync_base_age);
+    client.run(1); // Run the server's current time to catch up since clock sync is off for unit tests
     console.assert(client.getInstant(0, client.current_time).x == 10, "Player did not sync to the correct location ", client.get(0));
     // create an event 1 second in the future to change the velocity
     client.addEvent(new UpdatePlayerVelocity(2.01, {player_id:0, vx:0, vy:10}));
@@ -161,6 +162,8 @@ function synchronizeTwoPlayersChanging(){
 }
 
 function runAllTests(){
+    Timeline.smooth_clock_sync_rate = 0 ; // Turn off clocksmoothin for unit tests
+    Timeline.clock_sync_latency_fraction = 0 ; // Turn off latency estimation for clock syncing
     playerSerialize();
     moveSerialize();
     addPlayerAndMove();

--- a/timeline_core/TServer.js
+++ b/timeline_core/TServer.js
@@ -1,4 +1,3 @@
-var response_delay = 10;
 // A wrapper class for a Node server providing timeline sync over a websocket
 class TServer{
     
@@ -6,6 +5,8 @@ class TServer{
     port;
 
     web_socket_server ;
+
+    response_delay = 10; // Time to wait before responding (reduces load from lowl latency clients)
 
 
     constructor(timeline, port, WebSocket){
@@ -25,7 +26,7 @@ class TServer{
     receive(message, socket, timeline){
         //console.log("Received message => " + message);
 
-        setTimeout(this.respond, response_delay, message, socket, timeline);
+        setTimeout(this.respond, this.response_delay, message, socket, timeline);
         
     }
 


### PR DESCRIPTION
Change clock sync by update to consider latency, and add a gradual synchronization mechanism to reduce visible snapping when clocks aren't staying aligned (which is all the time apparently). 

Move time measurements into timeline, so timeline.run with no interval argument will run on real time.

Switch chat ChatClient to run on animation frame instead of setInterval. Not noticeable in Chrome but gets a more consistent frame-rate in Firefox.