### PR TITLE
Forward aggressive events

### DIFF
--- a/ChatClient.html
+++ b/ChatClient.html
@@ -99,11 +99,11 @@ function canvasApp() {
 
 		// Initialization stuff for canvas app goes here.
         my_id = timeline.getNextID(); // TODO race condition: this will be wrong if some other addObject event gets in before this one runs
+        
 		let player = new Player();
         player.x = 200 ;
         player.y = 200 ;
         player.name = "Player " + my_id  ; // TODO let the player input this
-        
         timeline.addObject(player, my_id, timeline.current_time) ;
         timeline.addEvent(new MovePlayer(timeline.current_time+0.1, {player_id:my_id, interval:interval }));
 	}
@@ -124,8 +124,8 @@ function canvasApp() {
 	    }
 
         visual_buffer = timeline.latency*2 ;
-        player_ahead = timeline.latency*2 ;
-        action_delay = timeline.latency*2 ;
+        player_ahead = timeline.latency*3 ;
+        action_delay = timeline.latency*3 ;
 
         let IDs = timeline.getAllIDs() ; // TODO way to fetch things by groups?
         for(let id in IDs){

--- a/ChatServer.js
+++ b/ChatServer.js
@@ -37,6 +37,9 @@ function setUpGame(){
 
 function tick(){
     timeline.run();
+    if(TServer.aggressive_event_forward){
+        tserver.forwardAggressiveEvents();
+    }
 }
 
 setUpGame();

--- a/timeline_core/TClient.js
+++ b/timeline_core/TClient.js
@@ -11,7 +11,7 @@ class TClient{
     active = false;
 
     // time to wait before responding (can be used with TServer response_time to simulate latency for testing)
-    sync_delay = 0; 
+    sync_delay = 0 ; 
     update_delay = 0 ;
 
     constructor(timeline, port){
@@ -59,7 +59,7 @@ class TClient{
     async respond(message){
         let in_packet = JSON.parse(message);
         if(in_packet.hash_data && in_packet.update){ // A Sync packet
-            let out_packet = client_global.timeline.synchronize(in_packet.hash_data, in_packet.update, true, client_global.timeline.current_time-Timeline.sync_base_age);
+            let out_packet = client_global.timeline.synchronize(in_packet.hash_data, in_packet.update, true);
             client_global.send(JSON.stringify(out_packet));
             // Not fully connected until clock has been sycnrhonzied, which takes 2 hops
             client_global.connected |= client_global.timeline.current_time >= in_packet.update.current_time;

--- a/timeline_core/TServer.js
+++ b/timeline_core/TServer.js
@@ -19,9 +19,19 @@ class TServer{
         this.web_socket_server.on('connection', ws => {
             console.log("New connection!");
             TServer.clients.push(ws);
+            //TODO add an API hook for server app to do something on connect
             ws.on('message', message => {
                 this.receive(message, ws, this.timeline) ;
             })
+            ws.on('close', function(){
+                for(let k=0; k < TServer.clients.length;k++){
+                    if(TServer.clients[k] == ws){
+                        TServer.clients.splice(k,1);
+                        break;
+                    }
+                }
+                //TODO add an API hook for server app to do something on client disconnect
+            });
         });
         console.log("Timeline Sync server opened on port " + port);
     }
@@ -50,7 +60,6 @@ class TServer{
 
     forwardAggressiveEvents(){
         for(let k=0;k<TServer.clients.length;k++){
-            //TODO check if client still connected
             let update_events = [];
             for(let e=0;e<TServer.quick_sends.length;e++){
                 if(TServer.quick_sends[e].source != TServer.clients[k]){ // don't send event back to source

--- a/timeline_core/TServer.js
+++ b/timeline_core/TServer.js
@@ -6,16 +6,19 @@ class TServer{
 
     web_socket_server ;
 
-    response_delay = 10; // Time to wait before responding (reduces load from low latency clients)
+    static response_delay = 5; // Time to wait before responding (reduces load from low latency clients)
 
+    static quick_sends = [];
+    static clients = []; // TODO finda cleaner way around this not being reliable on delayed events
+    static aggressive_event_forward = true;
 
     constructor(timeline, port, WebSocket){
         this.timeline = timeline ;
         this.port = port ;
         this.web_socket_server= new WebSocket.Server({ port: this.port });
-
         this.web_socket_server.on('connection', ws => {
             console.log("New connection!");
+            TServer.clients.push(ws);
             ws.on('message', message => {
                 this.receive(message, ws, this.timeline) ;
             })
@@ -24,18 +27,42 @@ class TServer{
     }
 
     receive(message, socket, timeline){
-        setTimeout(this.respond, this.response_delay, message, socket, timeline);
+        setTimeout(this.respond, TServer.response_delay, message, socket, timeline);
     }
 
     respond(message, socket, timeline){
         let in_packet = JSON.parse(message);
         if(in_packet.hash_data && in_packet.update){ // A Sync packet
-            let out_packet = timeline.synchronize(in_packet.hash_data, in_packet.update, false, timeline.current_time-Timeline.sync_base_age);
+            let out_packet = timeline.synchronize(in_packet.hash_data, in_packet.update, false);
             socket.send(JSON.stringify(out_packet));
         }else if(in_packet.update){ // update only packet doesn't respond
             timeline.applyUpdate(in_packet.update, false);
+            if(TServer.aggressive_event_forward){
+                for(let e = 0; e < in_packet.update.events.length; e++){
+                    // timeout simulates latency for aggressive forwarding
+                    setTimeout(TServer.quick_sends.push, TServer.response_delay, {source:socket, event:in_packet.update.events[e]});
+                }
+            } 
         }else{
             console.log(in_packet);
         }
+    }
+
+    forwardAggressiveEvents(){
+        for(let k=0;k<TServer.clients.length;k++){
+            //TODO check if client still connected
+            let update_events = [];
+            for(let e=0;e<TServer.quick_sends.length;e++){
+                if(TServer.quick_sends[e].source != TServer.clients[k]){ // don't send event back to source
+                    update_events.push(TServer.quick_sends[e].event);
+                }
+            }
+            if(update_events.length > 0){
+                let update = {current_time:this.timeline.current_time, events:update_events};
+                let out_packet = {update:update};
+                TServer.clients[k].send(JSON.stringify(out_packet));
+            }
+        }
+        TServer.quick_sends = [];
     }
 }

--- a/timeline_core/Timeline.js
+++ b/timeline_core/Timeline.js
@@ -65,6 +65,7 @@ class Timeline{
 
     // Adds a new event
     addEvent(new_event){
+        
         // TODO make sure events at the same time have their order set deterministically(maybe by hash) not by when they were added.
         let place = this.events.length;
         while(place > 0 && this.events[place-1].time > new_event.time){
@@ -83,7 +84,9 @@ class Timeline{
             this.client.sendUpdate(JSON.stringify({update:update}));
         }else{
             new_event.computeSerial();
+            //console.log(new_event);
         }
+        
     }
 
     // Add an object
@@ -115,7 +118,7 @@ class Timeline{
         for(let read_id in this.get_instances){
             event.read_ids[read_id] = true;
             //TODO don't hard crash if an event attempts to read somthing that is null
-            if(this.get_instances[read_id].hash() != this.instants[read_id][this.instant_read_index[read_id]].obj.last_hash){ // object was edited
+            if(this.get_instances[read_id] && this.get_instances[read_id].hash() != this.instants[read_id][this.instant_read_index[read_id]].obj.last_hash){ // object was edited
                 event.write_ids[read_id] = true;
                 //Delete all instants after edited one
                 this.instants[read_id].splice(this.instant_read_index[read_id]+1, this.instants[read_id].length);
@@ -177,8 +180,9 @@ class Timeline{
         return {base_time:base_time, current_time: this.current_time, base:base_hashes, events: event_hashes};
     }
 
-    synchronize(other_hashdata, my_update, allow_base_change, base_time){
+    synchronize(other_hashdata, my_update, allow_base_change){
         this.applyUpdate(my_update, allow_base_change);
+        let base_time = this.current_time-Timeline.sync_base_age ;
         let other_update = this.getUpdateFor(other_hashdata, base_time);
         return {update:other_update, hash_data:this.getHashData(base_time)};
     }
@@ -192,13 +196,15 @@ class Timeline{
         for(let k=0;k<other_hash_data.events.length; k++){
             has_event_hash[other_hash_data.events[k]] = true;
         }
-        //TODO we could be sending events that haven't been spawned yet but will be due to clock differences
+
         for(let k = 0; k < this.events.length; k++){
             if(this.events[k].time >= base_time){
                 // Don't send if they have it or if they have the event that spawned it
                 if(!has_event_hash[this.events[k].hash] && !has_event_hash[this.events[k].spawned_by]){
+                    
                     event_updates.push(this.events[k].serial);
                 }
+                has_event_hash[TEvent.hashSerial(this.events[k].serial)] = true;  // TODO cache hash compute
             }
         }
 
@@ -266,6 +272,7 @@ class Timeline{
             if(this.last_update_current_time){
                 this.latency = (update.current_time - this.last_update_current_time)*0.5;
                 let target_time = update.current_time + this.latency;
+
                 // If we're totally out of sync then snap back into sync
                 if(Math.abs(target_time-this.current_time) > Timeline.sync_base_age){
                     this.current_time = target_time ;
@@ -275,8 +282,8 @@ class Timeline{
                     this.current_time = this.current_time * (1-Timeline.smooth_clock_sync_rate) + target_time * Timeline.smooth_clock_sync_rate;
                 }
             }
+            this.last_update_current_time = update.current_time;
         }
-        this.last_update_current_time = update.current_time;
     }
 
     

--- a/timeline_core/Timeline.js
+++ b/timeline_core/Timeline.js
@@ -117,14 +117,13 @@ class Timeline{
         // Incorporate edited values fetched with get into the timeline instants
         for(let read_id in this.get_instances){
             event.read_ids[read_id] = true;
-            //TODO don't hard crash if an event attempts to read somthing that is null
-            if(this.get_instances[read_id] && this.get_instances[read_id].hash() != this.instants[read_id][this.instant_read_index[read_id]].obj.last_hash){ // object was edited
+            if(this.get_instances[read_id] && 
+                this.get_instances[read_id].hash() != this.instants[read_id][this.instant_read_index[read_id]].obj.last_hash){ // object was edited
                 event.write_ids[read_id] = true;
                 //Delete all instants after edited one
                 this.instants[read_id].splice(this.instant_read_index[read_id]+1, this.instants[read_id].length);
                 //Add new edit to the end of instants at this time
                 this.instants[read_id].push({time:this.executed_time, obj:this.get_instances[read_id]});
-
                 data_dirtied[read_id] = true; // dirty all IDs we edited this time
             }
         }
@@ -182,7 +181,7 @@ class Timeline{
 
     synchronize(other_hashdata, my_update, allow_base_change){
         this.applyUpdate(my_update, allow_base_change);
-        let base_time = this.current_time-Timeline.sync_base_age ;
+        let base_time = this.current_time - Timeline.sync_base_age ;
         let other_update = this.getUpdateFor(other_hashdata, base_time);
         return {update:other_update, hash_data:this.getHashData(base_time)};
     }
@@ -196,18 +195,16 @@ class Timeline{
         for(let k=0;k<other_hash_data.events.length; k++){
             has_event_hash[other_hash_data.events[k]] = true;
         }
-
         for(let k = 0; k < this.events.length; k++){
             if(this.events[k].time >= base_time){
                 // Don't send if they have it or if they have the event that spawned it
                 if(!has_event_hash[this.events[k].hash] && !has_event_hash[this.events[k].spawned_by]){
-                    
                     event_updates.push(this.events[k].serial);
                 }
+                // Don't send events spawned by events spawned by events the server has ad infinitum
                 has_event_hash[TEvent.hashSerial(this.events[k].serial)] = true;  // TODO cache hash compute
             }
         }
-
         let obj_updates = {};
         for(let id in this.instants){
             let base_obj = this.getInstant(id, base_time) ;
@@ -272,7 +269,6 @@ class Timeline{
             if(this.last_update_current_time){
                 this.latency = (update.current_time - this.last_update_current_time)*0.5;
                 let target_time = update.current_time + this.latency;
-
                 // If we're totally out of sync then snap back into sync
                 if(Math.abs(target_time-this.current_time) > Timeline.sync_base_age){
                     this.current_time = target_time ;
@@ -292,7 +288,6 @@ class Timeline{
     // Does not execute events, so new_base_time cannot exceed executed_time
     advanceBaseTime(new_base_time){
         for(let id in this.instants){
-            
             // Find first index past new_base time
             let i = 0 ;
             while(i < this.instants.length && this.instants[id][i].time <= new_base_time){


### PR DESCRIPTION
1) Makes the server forward aggressively sent client events to other clients without waiting for sync. 

2) Fixes a timing bug that could cause events created immediately after connection to timeout before being sent when aggressive sending is off.

3) Fixed an internal timeline crash that occurred if a user event attempted to get an object that wasn't defined at the time.