### PR TITLE
cache event hash set

### DIFF
--- a/PerfTest.html
+++ b/PerfTest.html
@@ -130,7 +130,7 @@ function perfTest(group_size=10){
                 let ID =  3 + k*4 ;
                 let tx = pattern_size*0.5 + radius*Math.cos(angle);
                 let ty = pattern_size*0.5 + radius*Math.sin(angle);
-                circle.addEvent(new UpdatePlayerTarget({player_id:ID, tx:tx, ty:ty}, time + interval*k*0.01));
+                circle.addEvent(new UpdatePlayerTarget({player_id:ID, tx:tx, ty:ty}, time + circle.default_event_delay + interval*k*0.01));
             }
         }
 

--- a/timeline_core/DeleteObject.js
+++ b/timeline_core/DeleteObject.js
@@ -1,17 +1,11 @@
 //Special event for deleting an object
 // You can use deleteObject on the timeline and it will create this for you.
 class DeleteObject extends TEvent{
-
-
     run(timeline){
         let ID = this.parameters.ID ;
         // fetch the object to get the correct pointer for execute to place the value
         let obj = timeline.get(ID);
         if(obj!=null){
-            if(ID == World.ID){
-                console.log("deleting " + ID + " with event.");
-                console.trace();
-            }
             // directly set the reference to the edited value to null to delete it in the timeline
             timeline.get_instances[ID] = null ;
         }else{

--- a/timeline_core/TEvent.js
+++ b/timeline_core/TEvent.js
@@ -44,7 +44,7 @@ class TEvent{
     }
 
     static hashSerial(serial){
-        return serial.split("").reduce(function(a,b){a=((a<<5)-a)+b.charCodeAt(0);return a&a},0); ;
+        return serial.split("").reduce(function(a,b){a=((a<<5)-a)+b.charCodeAt(0);return a&a},0) ;
     }
 
 }


### PR DESCRIPTION
Caches the map of event hashes to speed up the de-duplication check in Timeline.applyUpdate.
Also removes an unnecessary hash compute in Timeline.getUpdateFor.
This tiny change results in ~2-3x speedup in synchronization in the perf test.