### PR TITLE
Fix getNextID and addObject rollback

### DIFF
--- a/TimeWarpTest/ShootClient.html
+++ b/TimeWarpTest/ShootClient.html
@@ -98,7 +98,7 @@ function canvasApp() {
         interface_buttons["latency_label"] = new InterfaceButton(theCanvas.width-200, 10, 200, 40, "ping:?", 20, "#FFFFFF", "#000000", "#000000", 3, null);
 
 		// Initialization stuff for canvas app goes here.
-        my_id = timeline.getNextID(); // TODO race condition: this will be wrong if some other AddObject event gets in before this one runs
+        my_id = timeline.getNextID();
 		let player = new Player();
         player.x = 200 ;
         player.y = 200 ;
@@ -354,8 +354,7 @@ function sleep(ms) {
 <body>
 <div style="margin: auto; width: 1280px">
 	<div style="top: 50px">
-		<canvas id="canvasOne" width="1280" height="720"
-			oncontextmenu="return false;">
+		<canvas id="canvasOne" width="1280" height="720" oncontextmenu="return false;">
 			Your browser does not support HTML5 canvas.
 		</canvas>
 	</div>

--- a/TimeWarpTest/events/Fire.js
+++ b/TimeWarpTest/events/Fire.js
@@ -25,7 +25,7 @@ class Fire extends TEvent{
         b.vy = dy*n;
         b.shooter_id = this.parameters.player_id ;
         b.birth_time = this.time ;
-        let bullet_ID = Math.floor(this.time*1000000) ; // TODO fix possible race condition on getNextID being called by many clients at the same time
+        let bullet_ID = timeline.getNextID() ; // TODO fix possible race condition on getNextID being called by many clients at the same time
         timeline.addObject(b, bullet_ID);
 
         timeline.addEvent(new MoveBullet({bullet_id:bullet_ID, interval:this.parameters.interval }, this.time+this.parameters.interval + 0.0000001*(bullet_ID%1000)));

--- a/timeline_core/AddObject.js
+++ b/timeline_core/AddObject.js
@@ -4,7 +4,7 @@ class AddObject extends TEvent{
 
     run(timeline){
         let obj = TObject.getObjectBySerialized(this.parameters.type, this.parameters.ID, this.parameters.serial) ;
-        timeline.instants[obj.ID] = [{time:this.time, obj:obj}];
+        timeline.instants[obj.ID] = [{time:this.time + Timeline.event_write_delay, obj:obj}];
         timeline.instant_read_index[obj.ID] = 0;
         this.write_ids = {};
         this.write_ids[obj.ID] = true; 


### PR DESCRIPTION
getNextID now allocates a block for each client to use when creating objects outside of the timeline to avoid ID collisions. Objects created inside timeline events will be assigned IDs based on the creating event's hash (and step forward for each object past the first). This could still cause ID collisions if there are event hash collisions or near hash collisions, but that's a problem for the next version.