### PR TITLE
Add Time Warp to Shooter

### DIFF
--- a/TimeWarpTest/ShootClient.html
+++ b/TimeWarpTest/ShootClient.html
@@ -37,7 +37,6 @@ var kept_time = 3 ;
 var debug_timeline ;
 var port = 8081;
 var interval = 1/60.0;
-var base_age = 2 ;
 
 var my_id = -1 ;
 var player_stroke = "#D000D0" ;
@@ -79,6 +78,8 @@ function canvasApp() {
 	var mouse_down = false ;
 	//Which button is down (0 is left, 2 is right)
 	var mouse_button ;
+
+    var time_warp_mode = 0 ; // 0 is none, 1 is local only, 2 is speed of info
 	
 	var interface_buttons = {}; // Map of from name to buttons currently on the interface.
 	
@@ -95,8 +96,9 @@ function canvasApp() {
 	}
 	
 	function setupGame(){
-        interface_buttons["score_label"] = new InterfaceButton(200, 10, 200, 40, "ping:?", 20, "#FFFFFF", "#000000", "#000000", 3, null);
-        interface_buttons["latency_label"] = new InterfaceButton(theCanvas.width-200, 10, 200, 40, "ping:?", 20, "#FFFFFF", "#000000", "#000000", 3, null);
+        interface_buttons["score_label"] = new InterfaceButton(50, 10, 250, 40, "score:?", 20, "#FFFFFF", "#000000", "#000000", 3, null);
+        interface_buttons["time_label"] = new InterfaceButton(300, 10, 300, 40, "Time Mode:?", 20, "#FFFFFF", "#000000", "#000000", 3, null);
+        interface_buttons["latency_label"] = new InterfaceButton(600, 10, 200, 40, "ping:?", 20, "#FFFFFF", "#000000", "#000000", 3, null);
 
 		// Initialization stuff for canvas app goes here.
         my_id = timeline.getNextID();
@@ -124,13 +126,8 @@ function canvasApp() {
 	        }
 	    }
 
-        // Delay player events by ping so they arrive to all players before they actually happen
-        let delay = Math.max(0.02, timeline.ping*0.5);
-        timeline.setDefaultEventDelay(delay);
-        // Draw the player slightly in the future, so they see their own actions happening quicker
-        timeline.setObservedOffset(delay, my_id);
-        // Draw everything else slightly in the past to reduce visible rollbacks
-        timeline.setObservedOffset(-delay*0.75);
+        setObservableTimes();
+        
         
         
         let IDs = timeline.getAllIDs() ; // TODO way to fetch things by groups?
@@ -138,13 +135,13 @@ function canvasApp() {
         // Fetch all the observables once
         let stuff = {}
         for(let id of IDs){
-            let p = timeline.getObserved(id, true);
+            let p = timeline.getObserved(id);
             if(p==null){
                 continue ; 
             }
             stuff[id] = p ;
             if(id == my_id){
-                interface_buttons["score_label"].text = "Score: " + (p.hits-p.times_hit) +"  Hits:" + p.hits +"  Times Hit: " + p.times_hit;
+                interface_buttons["score_label"].text = "Hits:" + p.hits +"  Times Hit: " + p.times_hit;
             }
         }
 
@@ -157,21 +154,62 @@ function canvasApp() {
                 drawCircle(p.x, p.y, Bullet.radius, stuff[p.shooter_id].color, bullet_stroke, stroke_size);
             }
         }
-
-
-        
-
-		
 	}
+
+    function setObservableTimes(){
+
+        // Delay player events by ping so they arrive to all players before they actually happen
+        let delay = Math.max(0.02, timeline.ping*0.5);
+        let IDs = timeline.getAllIDs() ;
+        timeline.setDefaultEventDelay(delay);
+        timeline.setObservedOffset(-delay);
+        //console.log("Delay:" + delay);
+        if(time_warp_mode == 0){
+            interface_buttons["time_label"].text = "Time Warp: Off";
+            for(let id of IDs){
+                timeline.setObservedOffset(-delay, id);
+            }
+        }else if(time_warp_mode == 1){
+            interface_buttons["time_label"].text = "Time Warp: Player Only";
+            for(let id of IDs){
+                if(id == my_id){
+                    timeline.setObservedOffset(delay, my_id);
+                }else{
+                    timeline.setObservedOffset(-delay, id);
+                }
+            }
+        }else if(time_warp_mode == 2){
+            timeline.setObservedOffset(delay, my_id);
+            let me = timeline.getObserved(my_id); 
+            let world = timeline.getObserved(World.ID);
+            if(!me || !world){
+                return ;
+            }
+            interface_buttons["time_label"].text = "Time Warp: C= " + Math.round(world.max_info_speed) +" px/s" ;
+            for(let id of IDs){
+                let p = timeline.getObserved(id);
+                if(p instanceof Bullet || p instanceof Player){
+                    let d = Math.sqrt((me.x-p.x)*(me.x-p.x) + (me.y-p.y)*(me.y-p.y));
+                    let toff = delay - d / world.max_info_speed ; // warp time by distance
+                    if(p instanceof Player && id != my_id){ // other players will be buffered atleast their estimated latency
+                        toff = Math.min(toff,-delay);
+                    } 
+
+                    // Lock time adjustements to the range kept by the Timeline with some buffer
+                toff = Math.max(toff, -Timeline.sync_base_age*0.97);
+                toff = Math.min(toff, Timeline.execute_buffer*0.97);
+                timeline.setObservedOffset(toff, id);
+                }
+                
+            }
+        }
+    }
 	
     var last_tx=0;
     var last_ty=0;
 
 	function timeListener(){
-
-        let me = timeline.getObserved(my_id); // TODO is this messing up interpolation?
-        
-
+        let me = timeline.getObserved(my_id);
         let key_move = false;
         if(move_key_changed){
             let vx = 0;
@@ -209,7 +247,6 @@ function canvasApp() {
             let ty = mouse_y ;
             if(mouse_button == 0){ // left mouse button fires
                 if(timeline.current_time > me.last_fire_time + Player.fire_delay){ // can fire
-                
                     timeline.addEvent(new Fire({player_id:my_id, tx:tx, ty:ty, interval:interval}));
                 }
             }else if(!key_move){ // other mouse buttons move
@@ -269,15 +306,19 @@ function canvasApp() {
             if(character == 'L'){
                 let world = timeline.getObserved(World.ID) ;
                 let lag = world.send_delay + 25;
-                let warp = world.max_info_speed = world.max_info_speed;
+                let warp = 150*1000/lag ; // it should take lag amoun of time to travel 500pixels
                 console.log("Setting lag to " + lag);
                 timeline.addEvent(new ConfigureTime({send_delay:lag, max_info_speed:warp})) ;
             }else if(character == 'K'){
                 let world = timeline.getObserved(World.ID) ;
                 let lag = Math.max(2,world.send_delay - 25);
-                let warp = world.max_info_speed = world.max_info_speed;
+                let warp = 150*1000/lag ; // it should take lag amoun of time to travel 500pixels
                 console.log("Setting lag to " + lag);
                 timeline.addEvent(new ConfigureTime({send_delay:lag, max_info_speed:warp})) ;
+            }
+
+            if(character == 'T'){
+                time_warp_mode = (time_warp_mode+1)%3;
             }
 
         }else if(event.type == "keyup"){

--- a/TimeWarpTest/events/Fire.js
+++ b/TimeWarpTest/events/Fire.js
@@ -2,7 +2,7 @@ class Fire extends TEvent{
     run(timeline){
         //console.log("moveplayer " + this.parameters.player_id +" : " + this.time);
         let player = timeline.get(this.parameters.player_id);
-
+        
         if(!(player instanceof Player)){
             return ;
         }
@@ -27,7 +27,7 @@ class Fire extends TEvent{
         b.birth_time = this.time ;
         let bullet_ID = timeline.getNextID() ; // TODO fix possible race condition on getNextID being called by many clients at the same time
         timeline.addObject(b, bullet_ID);
-
+        timeline.observe_offset[bullet_ID] = timeline.observe_offset[b.shooter_id] ; // Not really allowed in this system but simulates time warp without delay
         timeline.addEvent(new MoveBullet({bullet_id:bullet_ID, interval:this.parameters.interval }, this.time+this.parameters.interval + 0.0000001*(bullet_ID%1000)));
 
     }

--- a/TimeWarpTest/objects/Bullet.js
+++ b/TimeWarpTest/objects/Bullet.js
@@ -1,8 +1,8 @@
 // A "player" for the 2D chat example
 class Bullet extends TObject{
-    static lifetime = 2;
+    static lifetime = 3;
     static radius = 10 ;
-    static speed = 600;
+    static speed = 400;
     x = 0;
     y = 0;
     vx = 0 ;
@@ -30,19 +30,18 @@ class Bullet extends TObject{
         this.birth_time = s.birth_time;
         this.shooter_id = s.shooter_id ;
     }
-
     interpolateFrom(last_observed, last_time, this_time){
         if(!last_observed){
             return this ;
         }
         let distance = Math.sqrt((this.x-last_observed.x)*(this.x-last_observed.x)+(this.y-last_observed.y)*(this.y-last_observed.y));
         let dt = this_time-last_time ;
-        if(distance/dt < Bullet.speed *1.1){
+        if(distance/dt < Bullet.speed *1.3){
             return this ;
         }else{
             let ip = new Bullet();
             ip.set(this.serialize());
-            let b = Bullet.speed *1.1*dt/distance ;
+            let b = Bullet.speed *1.3*dt/distance ;
             let a = 1-b;
             ip.x = a*last_observed.x + b* this.x ;
             ip.y = a*last_observed.y + b* this.y ;

--- a/TimeWarpTest/objects/Player.js
+++ b/TimeWarpTest/objects/Player.js
@@ -1,7 +1,7 @@
 // A "player" for the 2D chat example
 class Player extends TObject{
     static radius = 35 ;
-    static speed = 400 ;
+    static speed = 300 ;
     static fire_delay = 0.3 ;
     x = 0;
     y = 0;
@@ -44,12 +44,12 @@ class Player extends TObject{
         }
         let distance = Math.sqrt((this.x-last_observed.x)*(this.x-last_observed.x)+(this.y-last_observed.y)*(this.y-last_observed.y));
         let dt = this_time-last_time ;
-        if(distance/dt < Player.speed *1.1){
+        if(distance/dt < Player.speed *1.3){
             return this ;
         }else{
             let ip = new Player();
             ip.set(this.serialize());
-            let b = Player.speed *1.1*dt/distance ;
+            let b = Player.speed *1.3*dt/distance ;
             
             let a = 1-b;
             ip.x = a*last_observed.x + b* this.x ;


### PR DESCRIPTION
Adds the ability to toggle time warp mode in the shooter TimeWarpTest by pressing T in the client. Info speed is based on latency, which can be simulated with L and K.